### PR TITLE
Fixing broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You will need the following:
 Do the following:
 
 ```shell
-git clone https://github.com/plusreed/Bearbot
+git clone https://github.com/Bearbot/Bearbot
 cd Bearbot
 npm i
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bearbot
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2267369eaca84cd68e72373266e7b72d)](https://app.codacy.com/app/reed/Bearbot?utm_source=github.com&utm_medium=referral&utm_content=plusreed/Bearbot&utm_campaign=badger)
-[![Greenkeeper badge](https://badges.greenkeeper.io/plusreed/Bearbot.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/Bearbot/Bearbot.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.com/Bearbot/Bearbot.svg?branch=master)](https://travis-ci.com/Bearbot/Bearbot)
 [![Known Vulnerabilities](https://snyk.io/test/github/plusreed/bearbot/badge.svg?targetFile=package.json)](https://snyk.io/test/github/plusreed/bearbot?targetFile=package.json)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fplusreed%2FBearbot.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fplusreed%2FBearbot?ref=badge_shield)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2267369eaca84cd68e72373266e7b72d)](https://app.codacy.com/app/reed/Bearbot?utm_source=github.com&utm_medium=referral&utm_content=plusreed/Bearbot&utm_campaign=badger)
 [![Greenkeeper badge](https://badges.greenkeeper.io/plusreed/Bearbot.svg)](https://greenkeeper.io/)
-[![Build Status](https://travis-ci.com/plusreed/Bearbot.svg?branch=master)](https://travis-ci.com/plusreed/Bearbot)
+[![Build Status](https://travis-ci.com/Bearbot/Bearbot.svg?branch=master)](https://travis-ci.com/Bearbot/Bearbot)
 [![Known Vulnerabilities](https://snyk.io/test/github/plusreed/bearbot/badge.svg?targetFile=package.json)](https://snyk.io/test/github/plusreed/bearbot?targetFile=package.json)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fplusreed%2FBearbot.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fplusreed%2FBearbot?ref=badge_shield)
 [![Discord Bots](https://discordbots.org/api/widget/status/412139349770108939.svg)](https://discordbots.org/bot/412139349770108939)

--- a/cog/commit.js
+++ b/cog/commit.js
@@ -5,7 +5,7 @@ exports.run = (client, message, args) => {
         msg = execSync('git log -1 --pretty=%B').toString().trim(),
         branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
     
-    message.channel.send(`Current Bearbot commit: \`${hash}\`\nLast commit message:\n\`\`\`\n${msg}\n\`\`\`\nCurrent branch: \`${branch}\`\n\nInterested in seeing the source code? Look no further than here: <https://github.com/plusreed/Bearbot>`);
+    message.channel.send(`Current Bearbot commit: \`${hash}\`\nLast commit message:\n\`\`\`\n${msg}\n\`\`\`\nCurrent branch: \`${branch}\`\n\nInterested in seeing the source code? Look no further than here: <https://github.com/Bearbot/Bearbot>`);
 };
 
 exports.conf = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bearbot",
   "version": "1.0.0",
-  "description": "A general purpose Discord bot",
+  "description": "A general purpose Discord bot.",
   "main": "bear.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bear.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/plusreed/Bearbot.git"
+    "url": "https://github.com/Bearbot/Bearbot.git"
   },
   "scripts": {
     "test": "eslint . --ext .js",


### PR DESCRIPTION
Moving Bearbot to the Bearbot organization is pretty screwy for the GitHub apps, so this PR fixes some of the broken links in the README and such.